### PR TITLE
add .jekyll-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 Gemfile.lock
+.jekyll-metadata


### PR DESCRIPTION
Jekyll keep track of which files have not been modified since the site was last built, and which files will need to be regenerated on the next build with .jekyll-metadata. This file will not be included in the generated site. Suggested in https://jekyllrb.com/docs/structure/ .